### PR TITLE
fix: typeof() returns 'module' for LuzModule objects

### DIFF
--- a/luz/interpreter.py
+++ b/luz/interpreter.py
@@ -1461,6 +1461,8 @@ class Interpreter:
             return "list"
         if isinstance(value, dict):
             return "dict"
+        if isinstance(value, LuzModule):
+            return "module"
         return "unknown"
 
     # instanceof() returns true if value is an instance of the given class or


### PR DESCRIPTION
Fixes #4

typeof() was returning "unknown" for imported modules. Added a 
LuzModule check in builtin_typeof() so it correctly returns "module".

Tested with:
  import "math" as m
  write(typeof(m))  # now prints "module"

All tests pass.