### PR TITLE
feat: add reverse(), any(), and all() builtins

### DIFF
--- a/luz/interpreter.py
+++ b/luz/interpreter.py
@@ -370,6 +370,9 @@ class Interpreter:
             'len': self.builtin_len,
             'append': self.builtin_append,
             'pop': self.builtin_pop,
+            'reverse': self.builtin_reverse,
+            'any': self.builtin_any,
+            'all': self.builtin_all,
             'keys': self.builtin_keys,
             'values': self.builtin_values,
             'remove': self.builtin_remove,
@@ -1325,6 +1328,29 @@ class Interpreter:
             return list_obj.pop(index)
         except IndexError:
             raise IndexFault("Index out of range in pop() operation")
+
+    def builtin_reverse(self, value):
+        """Return a reversed copy of a list or string"""
+        if isinstance(value, list):
+            return list(reversed(value))
+        elif isinstance(value, str):
+            return value[::-1]
+        else:
+            raise TypeClashFault(
+                f"reverse() expects a list or string, got '{type(value).__name__}'"
+            )
+
+    def builtin_any(self, lst):
+        """Return True if at least one element is truthy"""
+        if not isinstance(lst, list):
+            raise TypeClashFault("any() requires a list")
+        return any(lst)
+
+    def builtin_all(self, lst):
+        """Return True if every element is truthy (True for empty list)"""
+        if not isinstance(lst, list):
+            raise TypeClashFault("all() requires a list")
+        return all(lst)
 
     def builtin_keys(self, dict_obj):
         if not isinstance(dict_obj, dict):

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -14,7 +14,7 @@ from luz.interpreter import Interpreter
 from luz.exceptions import (
     ArityFault, TypeViolationFault, ZeroDivisionFault, IndexFault,
     UndefinedSymbolFault, InvalidUsageFault, ImportFault, UserFault,
-    InheritanceFault
+    InheritanceFault, TypeClashFault
 )
 
 
@@ -482,6 +482,57 @@ class TestImports:
             interp.visit(Parser(Lexer('import "nonexistent.luz"').get_tokens()).parse())
         # Should not be stuck in imported_files
         assert not any("nonexistent" in p for p in interp.imported_files)
+
+
+# ── reverse, any, all builtins ────────────────────────────────────────────────
+
+class TestBuiltinsReverseAnyAll:
+    def test_reverse_list(self):
+        assert val("reverse([1, 2, 3])") == [3, 2, 1]
+
+    def test_reverse_string(self):
+        assert val('reverse("hello")') == "olleh"
+
+    def test_reverse_empty_list(self):
+        assert val("reverse([])") == []
+
+    def test_reverse_empty_string(self):
+        assert val('reverse("")') == ""
+
+    def test_reverse_original_unchanged(self):
+        interp = run('nums = [1, 2, 3]\nrev = reverse(nums)')
+        assert interp.global_env.lookup("nums") == [1, 2, 3]
+        assert interp.global_env.lookup("rev") == [3, 2, 1]
+
+    def test_reverse_invalid_type(self):
+        with pytest.raises(TypeClashFault):
+            val("reverse(42)")
+
+    def test_any_true(self):
+        assert val("any([false, false, true])") is True
+
+    def test_any_false(self):
+        assert val("any([false, false, false])") is False
+
+    def test_any_empty(self):
+        assert val("any([])") is False
+
+    def test_any_invalid_type(self):
+        with pytest.raises(TypeClashFault):
+            val('any("hello")')
+
+    def test_all_true(self):
+        assert val("all([true, true, true])") is True
+
+    def test_all_false(self):
+        assert val("all([true, false, true])") is False
+
+    def test_all_empty(self):
+        assert val("all([])") is True
+
+    def test_all_invalid_type(self):
+        with pytest.raises(TypeClashFault):
+            val('all("hello")')
 
 
 # ── Entry point ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

This PR implements three new built-in functions for the Luz language:

### reverse(collection)
- Returns a **reversed copy** of a list or string (original unchanged)
- Lists: reverse([1, 2, 3]) -> [3, 2, 1]
- Strings: reverse("hello") -> "olleh"
- Raises TypeClashFault for other types

### any(list)
- Returns true if at least one element is truthy
- Returns false for empty list
- Raises TypeClashFault if argument is not a list

### all(list)
- Returns true if every element is truthy
- Returns true for empty list (matches Python convention)
- Raises TypeClashFault if argument is not a list

## Changes
- luz/interpreter.py: Added 3 builtins to dict + 3 implementation methods
- tests/test_suite.py: Added TestBuiltinsReverseAnyAll with 14 test cases

## Fixes
- Closes #30 (reverse)
- Closes #29 (any, all)