### PR TITLE
feat: add index() and insert() builtins

### DIFF
--- a/luz/interpreter.py
+++ b/luz/interpreter.py
@@ -402,6 +402,8 @@ class Interpreter:
             'sign': self.builtin_sign,
             'odd': self.builtin_odd,
             'even': self.builtin_even,
+            'index': self.builtin_index,
+            'insert': self.builtin_insert,
             # Trigonometric Functions - all angles in radians
             'sin': self.builtin_sin,
             'cos': self.builtin_cos,
@@ -1770,6 +1772,24 @@ class Interpreter:
     def builtin_even(self, x):
         self._require_num(x, 'even')
         return int(x) % 2 == 0
+
+    def builtin_index(self, list_obj, value):
+        """Return the index of value in list, or -1 if not found."""
+        if not isinstance(list_obj, list):
+            raise ArgumentFault("index() requires a list as its first argument")
+        try:
+            return list_obj.index(value)
+        except ValueError:
+            return -1
+
+    def builtin_insert(self, list_obj, index, value):
+        """Insert value at index in list. Returns null."""
+        if not isinstance(list_obj, list):
+            raise ArgumentFault("insert() requires a list as its first argument")
+        if not isinstance(index, int):
+            raise TypeViolationFault("Index for insert() must be an integer")
+        list_obj.insert(index, value)
+        return None
 
     # ── Random primitives (used by luz-random stdlib) ──────────────────────────
 

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -484,6 +484,44 @@ class TestImports:
         assert not any("nonexistent" in p for p in interp.imported_files)
 
 
+class TestBuiltinIndexInsert:
+    def test_index_found(self):
+        assert val('index([10, 20, 30], 20)') == 1
+
+    def test_index_not_found(self):
+        assert val('index([10, 20, 30], 99)') == -1
+
+    def test_index_first_element(self):
+        assert val('index(["a", "b", "c"], "a")') == 0
+
+    def test_index_empty_list(self):
+        assert val('index([], 1)') == -1
+
+    def test_index_non_list_raises(self):
+        with pytest.raises(Exception):
+            val('index("hello", "e")')
+
+    def test_insert_basic(self):
+        assert env('xs = [1, 2, 3]\ninsert(xs, 1, 99)\nxs', 'xs') == [1, 99, 2, 3]
+
+    def test_insert_at_end(self):
+        assert env('xs = [1, 2]\ninsert(xs, 2, 99)\nxs', 'xs') == [1, 2, 99]
+
+    def test_insert_at_start(self):
+        assert env('xs = [1, 2]\ninsert(xs, 0, 99)\nxs', 'xs') == [99, 1, 2]
+
+    def test_insert_returns_null(self):
+        assert val('xs = [1]\ninsert(xs, 0, 99)') is None
+
+    def test_insert_non_list_raises(self):
+        with pytest.raises(Exception):
+            val('insert("hello", 0, "x")')
+
+    def test_insert_non_int_index_raises(self):
+        with pytest.raises(Exception):
+            val('xs = [1]\ninsert(xs, "a", 99)')
+
+
 # ── Entry point ───────────────────────────────────────────────────────────────
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Add two new builtin functions for list operations:

### index(list, value)
- Returns the index of `value` in `list`
- Returns -1 if not found (instead of raising an error)
- Raises ArgumentFault if first argument is not a list

### insert(list, index, value)
- Inserts `value` at `index` in `list` (mutates in place)
- Returns null
- Raises ArgumentFault if first argument is not a list
- Raises TypeViolationFault if index is not an integer

## Tests

11 test cases in `TestBuiltinIndexInsert`:
- `test_index_found`, `test_index_not_found`, `test_index_first_element`
- `test_index_empty_list`, `test_index_non_list_raises`
- `test_insert_basic`, `test_insert_at_end`, `test_insert_at_start`
- `test_insert_returns_null`, `test_insert_non_list_raises`
- `test_insert_non_int_index_raises`

## Changes
- `luz/interpreter.py`: Added 2 builtins to dict + 2 implementation methods
- `tests/test_suite.py`: Added TestBuiltinIndexInsert class with 11 tests

Fixes #27 (index) and #28 (insert)