### PR TITLE
[luzc] scan_return_type: defer to infer_type for BinOp returns (#99)

### DIFF
--- a/compiler/src/ccodegen.cpp
+++ b/compiler/src/ccodegen.cpp
@@ -279,7 +279,7 @@ private:
     }
 
     // Scan a block for return-with-value to infer a return type.
-    static std::string scan_return_type(const HirBlock& body) {
+    std::string scan_return_type(const HirBlock& body) {
         for (auto& n : body) {
             if (n->kind == HirKind::Return) {
                 auto* r = static_cast<HirReturn*>(n.get());
@@ -298,7 +298,14 @@ private:
                         auto* l = static_cast<HirLoad*>(r->value.get());
                         return c_type(l->type);  // may be long long for unknown
                     }
-                    if (r->value->kind == HirKind::BinOp) return "long long";
+                    // BinOp used to hardcode "long long", which truncated
+                    // float-returning expressions like `(a + b) / 2.0` to
+                    // an int return type and broke any function that
+                    // returned a non-int arithmetic result (issue #99).
+                    // Defer to infer_type so the HIR's type tag drives the
+                    // forward-declared return type.
+                    if (r->value->kind == HirKind::BinOp)
+                        return infer_type(r->value.get());
                     if (r->value->kind == HirKind::Call) {
                         auto* c = static_cast<HirCall*>(r->value.get());
                         return c_ret_type(c->return_type);

--- a/compiler/tests/CMakeLists.txt
+++ b/compiler/tests/CMakeLists.txt
@@ -7,6 +7,7 @@ add_executable(luz_tests
     test_typechecker.cpp
     test_hir.cpp
     test_e2e.cpp
+    test_ccodegen.cpp
 )
 
 target_include_directories(luz_tests PRIVATE
@@ -25,6 +26,7 @@ target_sources(luz_tests PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/../src/typechecker.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/../src/hir.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/../src/codegen.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/ccodegen.cpp
 )
 
 include(CTest)

--- a/compiler/tests/test_ccodegen.cpp
+++ b/compiler/tests/test_ccodegen.cpp
@@ -1,0 +1,76 @@
+// test_ccodegen.cpp — C source emitter coverage for the inferred return-type
+// path (issue #99 and similar). The LLVM IR pipeline already has its own
+// e2e coverage; this file exercises ccodegen specifically.
+
+#include "test_runner.hpp"
+
+#include "luz/ccodegen.hpp"
+#include "luz/hir.hpp"
+#include "luz/lexer.hpp"
+#include "luz/parser.hpp"
+
+#include <sstream>
+#include <string>
+
+namespace {
+
+std::string emit_c_source(const std::string& source) {
+    auto tokens  = luz::lex(source);
+    auto program = luz::parse(tokens);
+    auto hir     = luz::lower_to_hir(program);
+    std::ostringstream out;
+    luz::emit_c(out, hir, "test.luz");
+    return out.str();
+}
+
+bool contains(const std::string& haystack, const std::string& needle) {
+    return haystack.find(needle) != std::string::npos;
+}
+
+}  // namespace
+
+// Regression test for #99 — `scan_return_type` used to hardcode the
+// forward-declared return type for any function whose body returned a
+// `BinOp` to `long long`, regardless of the actual operand types. A
+// function returning `(a + b) / 2.0` therefore got declared as
+// `long long average(double, double)` and silently truncated the
+// result to an int. The fix delegates to `infer_type` so the HIR's
+// type tag drives the declaration.
+TEST_CASE("ccodegen: float-returning function with no explicit return type emits double") {
+    const auto c_src = emit_c_source(
+        "function average(a: float, b: float) {\n"
+        "    return (a + b) / 2.0\n"
+        "}\n"
+        "write(average(1.0, 2.0))\n");
+
+    // Must NOT advertise a long long return — that's the #99 truncation.
+    CHECK(!contains(c_src, "long long average"));
+    // Must declare and define the function as returning double.
+    CHECK(contains(c_src, "double average("));
+}
+
+// Sanity: the bug was return-type specific. Int-returning binop
+// functions must still come out as `long long`.
+TEST_CASE("ccodegen: int-returning function with no explicit return type still emits long long") {
+    const auto c_src = emit_c_source(
+        "function add(a: int, b: int) {\n"
+        "    return a + b\n"
+        "}\n"
+        "write(add(1, 2))\n");
+
+    CHECK(contains(c_src, "long long add("));
+    CHECK(!contains(c_src, "double add("));
+}
+
+// String concatenation also returns char* via the BinOp path. The
+// pre-fix code would have mis-typed this as `long long` too.
+TEST_CASE("ccodegen: string-concat function with no explicit return type emits char*") {
+    const auto c_src = emit_c_source(
+        "function greet(who: string) {\n"
+        "    return \"hello, \" + who\n"
+        "}\n"
+        "write(greet(\"world\"))\n");
+
+    CHECK(contains(c_src, "char* greet("));
+    CHECK(!contains(c_src, "long long greet"));
+}


### PR DESCRIPTION
Closes #99.

## What

`scan_return_type()` in `compiler/src/ccodegen.cpp` had:

```cpp
if (r->value->kind == HirKind::BinOp) return "long long";
```

When a function omits its explicit return type, ccodegen falls back
to `scan_return_type` to forward-declare it. Any function whose body
returned a non-int arithmetic expression — e.g. the issue's repro:

```luz
function average(a: float, b: float) {
    return (a + b) / 2.0
}
write(average(1.0, 2.0))
```

— got declared as `long long average(double, double)`, silently
truncating the result. The `write` printed `1` instead of `1.5`.

## Fix

- Drop the `static` qualifier from `scan_return_type` so it can
  call the instance method `infer_type`.
- Replace the hardcoded `"long long"` line with
  `return infer_type(r->value.get())`. `infer_type` already
  consults the HIR's type tag (`HirBinOp::type`) and handles
  comparison ops (returns `int`), string concatenation (returns
  `char*`), and arithmetic (delegates to `c_type(b->type)`)
  correctly.

## Tests

`compiler/tests/test_ccodegen.cpp` (new):

- `ccodegen: float-returning function with no explicit return type
  emits double` — the #99 regression.
- `ccodegen: int-returning function with no explicit return type
  still emits long long` — sanity, bug was return-type specific.
- `ccodegen: string-concat function with no explicit return type
  emits char*` — would also have been mistyped under the old code.

`compiler/tests/CMakeLists.txt` updated to compile `ccodegen.cpp`
into the test binary and include the new file.

## Verification

- Manual `clang++ -std=c++17` build of `luz_tests` →
  `===  181 passed  /  0 failed  ===`.
- Reverting the one-line fix in `scan_return_type` makes the
  float-function and string-concat subtests of the new suite fail
  with diagnostics `'long long average' was found` /
  `missing 'char* greet'`, confirming the test catches the
  regression.
- Manual repro from the issue body:
  - pre-fix `luzc avg.luz --emit-c` → `long long average(double, double);`
  - post-fix `luzc avg.luz --emit-c` → `double average(double, double);`