### PR TITLE
fix(runtime): free old string in dict_set on overwrite (#98)

### DIFF
--- a/compiler/runtime/luz_rt.c
+++ b/compiler/runtime/luz_rt.c
@@ -77,7 +77,16 @@ static void dict_grow(LuzDict* d) {
 
 static void dict_set(LuzDict* d, const char* key, LuzVal val) {
     LuzEntry* e = dict_find(d, key);
-    if (e) { e->val = val; return; }
+    if (e) {
+        /* Free the previous string heap allocation before overwriting.
+         * Without this, every dict_set("key", str) on an existing
+         * string-tagged entry leaks the previous strdup'd buffer
+         * (issue #98). The tag check matches what dict_remove() does
+         * a few lines below. */
+        if (e->val.tag == 4) free(e->val.s);
+        e->val = val;
+        return;
+    }
     dict_grow(d);
     d->entries[d->size].key = strdup(key);
     d->entries[d->size].val = val;


### PR DESCRIPTION
Closes #98.

## Summary
`dict_set` in `compiler/runtime/luz_rt.c` overwrote an existing entry's value struct directly, without freeing the previous heap allocation:
```c
if (e) { e->val = val; return; }   // old e->val.s leaked
```
Every `luz_dict_set_str` call against an existing string-tagged key leaked the previous `strdup`'d buffer. In a long-running program — or any class field that gets reassigned — the heap grows unboundedly.

## Fix
Mirror the tag check that `dict_remove` already performs a few lines below: free `e->val.s` when the previous value was tagged as a string (`tag == 4`). Non-string tags (int, float, bool) own nothing on the heap, so the pre-existing `e->val = val` overwrite remains a no-op for them.

```c
if (e) {
    if (e->val.tag == 4) free(e->val.s);
    e->val = val;
    return;
}
```

## Test plan
The current `compiler/tests/CMakeLists.txt` does not compile `luz_rt.c` into the test binary (existing tests verify compiler IR output, not runtime behavior), so no unit-level regression test is added in this PR. The fix is one branch and matches the proposed fix in the issue.

Suggested follow-up if maintainers want runtime-level coverage: add `luz_rt.c` to `target_sources` for a new `test_runtime.cpp` file and assert with valgrind/ASan that `dict_set(d, \"k\", str_a)` followed by `dict_set(d, \"k\", str_b)` reports zero leaked bytes.