### PR TITLE
fix(luzc): luz_powi raises on negative exponent (#97)

### DIFF
--- a/compiler/runtime/luz_rt.c
+++ b/compiler/runtime/luz_rt.c
@@ -179,6 +179,14 @@ const char* luz_get_error(void) {
 // ── Math ──────────────────────────────────────────────────────────────────────
 
 long long luz_powi(long long base, long long exp) {
+    // Without this guard, the integer ** operator silently returned 1 for
+    // any negative exponent because the `while (exp-- > 0)` loop never
+    // entered (issue #97). 2 ** -1 mathematically is 0.5, not 1; emit a
+    // structured fault instead so callers can attempt/rescue or die loudly.
+    if (exp < 0) {
+        luz_alert_throw("negative exponent in integer power");
+        return 0;
+    }
     long long result = 1;
     while (exp-- > 0) result *= base;
     return result;

--- a/compiler/src/codegen.cpp
+++ b/compiler/src/codegen.cpp
@@ -1437,9 +1437,23 @@ private:
     // ── luz_powi helper ───────────────────────────────────────────────────────
 
     void emit_powi_helper() {
+        // The error message string has 35 bytes including the trailing NUL,
+        // matching the C-runtime version of luz_powi in luz_rt.c. Both
+        // backends route negative-exponent calls through @luz_alert_throw
+        // so attempt/rescue blocks see a uniform fault (issue #97).
         final_out_ <<
+            "\n@.luz_powi_neg_msg = private unnamed_addr constant [35 x i8]"
+            " c\"negative exponent in integer power\\00\", align 1\n"
             "\ndefine i64 @luz_powi(i64 %base, i64 %exp) {\n"
             "entry:\n"
+            "  %neg_chk = icmp slt i64 %exp, 0\n"
+            "  br i1 %neg_chk, label %pw_neg, label %pw_init\n"
+            "pw_neg:\n"
+            "  %msg = getelementptr inbounds [35 x i8],"
+            " [35 x i8]* @.luz_powi_neg_msg, i64 0, i64 0\n"
+            "  call void @luz_alert_throw(i8* %msg)\n"
+            "  unreachable\n"
+            "pw_init:\n"
             "  %result.addr = alloca i64\n"
             "  %base2.addr  = alloca i64\n"
             "  %exp2.addr   = alloca i64\n"

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -221,6 +221,23 @@ class TestArithmetic:
     def test_power(self):
         assert out("write(2 ** 10)") == ["1024"]
 
+    def test_power_zero_exponent(self):
+        # x ** 0 = 1 for any base — the existing behaviour, pinned here so
+        # the negative-exponent fix doesn't regress the boundary case.
+        assert out("write(7 ** 0)") == ["1"]
+
+    def test_power_negative_exponent_raises_runtime_fault(self):
+        # Regression for #97: 2 ** -1 used to silently return 1 (the
+        # `while (exp-- > 0)` loop never entered for negative exp). Now
+        # both backends route through @luz_alert_throw so attempt/rescue
+        # can catch it and unhandled cases die loudly.
+        result = run_fails("write(2 ** -1)")
+        # luz_alert_throw writes "Error: <msg>" to stderr when the fault
+        # bubbles to top-level.
+        assert "negative exponent" in result.stderr.lower(), (
+            f"expected 'negative exponent' in stderr; got:\n{result.stderr}"
+        )
+
     def test_negative_numbers(self):
         assert out("write(0 - 5 + 3)") == ["-2"]
 


### PR DESCRIPTION
## Summary

Closes #97.

\`luz_powi(base, exp)\` silently returned \`1\` for any negative exponent
because the \`while (exp-- > 0)\` loop never entered. So \`2 ** -1\` —
which is mathematically \`0.5\`, not \`1\` — produced \`1\` at runtime
with no warning.

The bug exists in **both** compiler backends:

- \`compiler/runtime/luz_rt.c::luz_powi\` (used by \`ccodegen\` to emit
  C source linked against the runtime).
- \`compiler/src/codegen.cpp::emit_powi_helper\` (used by \`codegen\` to
  emit inline LLVM IR — a distinct function from the C-runtime one).

This PR fixes both. Both call sites now check \`exp < 0\` up front and
route through \`luz_alert_throw(\"negative exponent in integer power\")\`
so:

- top-level callers see a uniform \`Error: negative exponent in
  integer power\` on stderr and a non-zero exit (consistent with
  other runtime faults like \`pop from empty list\`);
- and \`attempt\` / \`rescue\` blocks can catch the fault.

The LLVM helper grows a small \`pw_neg\` block plus a private string
constant \`@.luz_powi_neg_msg\` (35 bytes including the trailing NUL,
matching the C-runtime message exactly).

## Test plan

Two cases added to \`tests/test_suite.py::TestArithmetic\`:

- \`test_power_negative_exponent_raises_runtime_fault\` — \`2 ** -1\`
  fails compile+run with \"negative exponent\" in stderr.
- \`test_power_zero_exponent\` — \`7 ** 0 == 1\` (boundary case so the
  new branch can't regress \`exp == 0\`).

I couldn't build LLVM/CMake locally, so this relies on CI to run the
end-to-end suite. The diff is small and the IR change mirrors the C
runtime fix; happy to iterate on review.